### PR TITLE
Change RequireNSFWAttribute to follow Discord TOS

### DIFF
--- a/Addons/Preconditions/RequireNSFW.cs
+++ b/Addons/Preconditions/RequireNSFW.cs
@@ -9,7 +9,7 @@ namespace Valerie.Addons.Preconditions
         public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext Context, CommandInfo Info, IServiceProvider Provider)
         {
             var Channel = Context.Channel as Discord.ITextChannel;
-            if (Channel.IsNsfw || Channel.Name.Contains("nsfw")) return Task.FromResult(PreconditionResult.FromSuccess());
+            if (Channel.IsNsfw) return Task.FromResult(PreconditionResult.FromSuccess());
             return Task.FromResult(PreconditionResult.FromError($"**{Info.Name}** command can only be ran in NSFW channel, pervert."));
         }
     }


### PR DESCRIPTION
Channels can have "NSFW" in their names even if the NSFW setting is disable channel-wise. Checking for it in a NSFW check is bad and will break Discord TOS in some cases.